### PR TITLE
Varnishing colorbar format for 0 values

### DIFF
--- a/src/plopm/utils/write.py
+++ b/src/plopm/utils/write.py
@@ -1045,6 +1045,10 @@ def mapits(dic, t, n, k):
             endpoint=True,
         )
     func = "lambda x, _: f'{x:" + dic["cformat"][n] + "}'"
+    frmt = "{:" + dic["cformat"][n] + "}"
+    for i, val in enumerate(vect):
+        if abs(float(frmt.format(val))) == 0:
+            vect[i] = 0
     if (
         var.lower() != "wells"
         and var.lower() != "faults"


### PR DESCRIPTION
This PR changes values from `-0.0` to `0.0` in the colorbars for smaller values than the provided `-cformat`. 