### PR TITLE
Using rporv when available

### DIFF
--- a/src/plopm/utils/readers.py
+++ b/src/plopm/utils/readers.py
@@ -1338,6 +1338,8 @@ def get_quantity(dic, name, n, nrst, m):
             quan = np.array(dic["init"]["SATNUM"][0]) * 0
         elif dic["unrst"].has_kw(names[0]):
             quan = np.array(dic["unrst"][names[0]][nrst]) * 1.0
+            if dic["unrst"].has_kw("RPORV"):
+                dic["porv"][dic["porv"] > 0] = np.array(dic["unrst"]["RPORV"][nrst])
         elif names[0].lower() in dic["mass"] + dic["xmass"]:
             quan = handle_mass(dic, names[0].lower(), nrst) * skl
             if names[0].lower() in dic["mass"]:
@@ -1381,6 +1383,8 @@ def get_quantity(dic, name, n, nrst, m):
             quan = np.array(dic["init"]["SATNUM"]) * 0
         elif dic["unrst"].count(names[0]):
             quan = dic["unrst"][names[0], nrst]
+            if dic["unrst"].count("RPORV"):
+                dic["porv"][dic["porv"] > 0] = np.array(dic["unrst"]["RPORV", nrst])
         elif names[0].lower() in dic["mass"] + dic["xmass"]:
             quan = handle_mass(dic, names[0].lower(), nrst) * skl
             if names[0].lower() in dic["mass"]:

--- a/tests/test_generic_deck.py
+++ b/tests/test_generic_deck.py
@@ -37,7 +37,8 @@ def test_generic_deck():
         check=True,
     )
     os.system(
-        "flow SPE10_MODEL2.DATA --parsing-strictness=low --enable-dry-run=true & wait\n"
+        "flow SPE10_MODEL2.DATA --parsing-strictness=low --enable-dry-run=1 "
+        "--check-satfunc-consistency=0"
     )
     for slide, name, nslide, logs in zip(
         ["4,,", ",8,", ",,20"],


### PR DESCRIPTION
Using the pore volume at reservoir conditions to compute averaged quantities when available, i.e., for decks run with the `RPORV` in `RPTRST`.