### PR TITLE
Small fixes for slides and diff

### DIFF
--- a/src/plopm/utils/initialization.py
+++ b/src/plopm/utils/initialization.py
@@ -31,6 +31,7 @@ def ini_dic(cmdargs):
     names = [var.split(" ") for var in names]
     dic["namens"] = names
     dic["mode"] = cmdargs["mode"].strip()
+    dic["diff"] = cmdargs["diff"].strip()
     dic["ensemble"] = int(cmdargs["ensemble"])
     if names[0][0][-1] in [".", "/"]:
         folders = names[0]
@@ -50,6 +51,18 @@ def ini_dic(cmdargs):
                             names[-1].append(os.path.join(root, file)[2:-7])
             names[-1] = sorted(names[-1])
     dic["names"], dic["name"] = names, names[0][0]
+    if dic["diff"]:
+        if dic["diff"][-1] in [".", "/"]:
+            folders = dic["diff"]
+            names = []
+            for i, folder in enumerate(folders):
+                if folder[0] != ".":
+                    folder = "./" + folder
+                for root, _, files in os.walk(folder):
+                    for file in files:
+                        if file.endswith(".EGRID"):
+                            dic["diff"] = os.path.join(root, file)[2:-6]
+                            break
     dic["coords"] = ["x", "y", "z"]
     dic["dual"] = (cmdargs["dual"].strip()).split(",")
     dic["scale"] = int(cmdargs["scale"])
@@ -82,7 +95,6 @@ def ini_dic(cmdargs):
     dic["cnum"] = (cmdargs["cnum"].strip()).split(",")
     dic["mask"] = cmdargs["mask"].strip()
     dic["suptitle"] = cmdargs["suptitle"].strip()
-    dic["diff"] = cmdargs["diff"].strip()
     dic["clabel"] = cmdargs["clabel"].strip()
     dic["labels"] = (cmdargs["labels"].strip()).split("   ")
     dic["labels"] = [var.split("  ") for var in dic["labels"]]
@@ -177,7 +189,9 @@ def ini_dic(cmdargs):
         for i, var in enumerate(dic["slide"]):
             for j, val in enumerate(var):
                 if val[0] != -2:
-                    if ":" in val:
+                    if val == ":":
+                        pass
+                    elif ":" in val:
                         dic["slide"][i][j] = [
                             int(val.split(":")[0]) - 1,
                             int(val.split(":")[1]),
@@ -453,6 +467,12 @@ def ini_slides(dic, n):
         dic (dict): Modified global dictionary
 
     """
+    if dic["slide"][n][0] == ":":
+        dic["slide"][n][0] = [0, dic["nx"]]
+    elif dic["slide"][n][1] == ":":
+        dic["slide"][n][1] = [0, dic["ny"]]
+    elif dic["slide"][n][2] == ":":
+        dic["slide"][n][2] = [0, dic["nz"]]
     if dic["slide"][n][0][0] > -1:
         dic["mx"], dic["my"] = 2 * dic["ny"] - 1, 2 * dic["nz"] - 1
         dic["xmeaning"], dic["ymeaning"] = "y", "z"

--- a/src/plopm/utils/mapping.py
+++ b/src/plopm/utils/mapping.py
@@ -25,7 +25,11 @@ def handle_slide_x(dic, n):
         dic (dict): Modified global dictionary
 
     """
-    if dic["slide"][n][0][0] == dic["slide"][n][0][1] - 1:
+    if dic["slide"][n][0][0] == ":":
+        dic["slide"][n][0] = [0, dic["nx"]]
+        dic["tslide"] = f", slide i=0:{dic['nx']}"
+        dic["nslide"] = f"0:{dic['nx']},j,k"
+    elif dic["slide"][n][0][0] == dic["slide"][n][0][1] - 1:
         dic["tslide"] = f", slide i={dic['slide'][n][0][0]+1}"
         dic["nslide"] = f"{dic['slide'][n][0][0]+1},j,k"
     else:
@@ -45,7 +49,11 @@ def handle_slide_y(dic, n):
         dic (dict): Modified global dictionary
 
     """
-    if dic["slide"][n][1][0] == dic["slide"][n][1][1] - 1:
+    if dic["slide"][n][1][0] == ":":
+        dic["slide"][n][1] = [0, dic["ny"]]
+        dic["tslide"] = f", slide j=0:{dic['ny']}"
+        dic["nslide"] = f"i,0:{dic['ny']},k"
+    elif dic["slide"][n][1][0] == dic["slide"][n][1][1] - 1:
         dic["tslide"] = f", slide j={dic['slide'][n][1][0]+1}"
         dic["nslide"] = f"i,{dic['slide'][n][1][0]+1},k"
     else:
@@ -65,7 +73,11 @@ def handle_slide_z(dic, n):
         dic (dict): Modified global dictionary
 
     """
-    if dic["slide"][n][2][0] == dic["slide"][n][2][1] - 1:
+    if dic["slide"][n][2][0] == ":":
+        dic["slide"][n][2] = [0, dic["nz"]]
+        dic["tslide"] = f", slide k={1}:{dic['nz']}"
+        dic["nslide"] = f"i,j,{1}:{dic['nz']}"
+    elif dic["slide"][n][2][0] == dic["slide"][n][2][1] - 1:
         dic["tslide"] = f", slide k={dic['slide'][n][2][0]+1}"
         dic["nslide"] = f"i,j,{dic['slide'][n][2][0]+1}"
     else:
@@ -435,7 +447,7 @@ def map_xycoords(dic, var, quan, n):
         dic (dict): Modified global dictionary
 
     """
-    dual = dic["dual"][n] == "1"
+    dual = dic["dual"][n] == "1" if n < len(dic["dual"]) else False
     ny = int((dic["ny"] - 1) / 2) if dual else dic["ny"]
     for j in range(ny):
         for i in range(dic["nx"]):

--- a/src/plopm/utils/readers.py
+++ b/src/plopm/utils/readers.py
@@ -172,6 +172,8 @@ def get_histogram(dic, quans, nrst):
         var[act] = handle_mass(dic, quans[0].lower(), nrst)
     elif quans[0].lower() in dic["caprock"]:
         var[act], _ = handle_caprock(dic, quans[0].lower(), nrst)
+    elif quans[0].lower() in ["swat", "soil", "sgas"]:
+        var[act] = handle_saturation(dic, quans[0].lower(), nrst)
     else:
         print(f"Unknow -v variable ({quans[0]}).")
         sys.exit()
@@ -189,6 +191,8 @@ def get_histogram(dic, quans, nrst):
                 quan1 = handle_mass(dic, val.lower(), nrst)
             elif val.lower() in dic["caprock"]:
                 quan1 = handle_caprock(dic, val.lower(), nrst)
+            elif val.lower() in ["swat", "soil", "sgas"]:
+                quan1 = handle_saturation(dic, val.lower(), nrst)
             else:
                 print(f"Unknow -v variable ({val}).")
                 sys.exit()
@@ -257,6 +261,8 @@ def compute_distance(dic, quans, n):
                 var[act] = 1.0 * dic["unrst"][quans[0].upper(), nrst]
             elif quans[0].lower() in dic["mass"] + dic["xmass"]:
                 var[act] = handle_mass(dic, quans[0].lower(), nrst)
+            elif quans[0].lower() in ["swat", "soil", "sgas"]:
+                var[act] = handle_saturation(dic, quans[0].lower(), nrst)
             else:
                 print(f"Unknow -v variable ({quans[0]}).")
                 sys.exit()
@@ -272,6 +278,8 @@ def compute_distance(dic, quans, n):
                         quan1 = 1.0 * dic["unrst"][val.upper(), nrst]
                     elif val.lower() in dic["mass"] + dic["xmass"]:
                         quan1 = handle_mass(dic, val.lower(), nrst)
+                    elif val.lower() in ["swat", "soil", "sgas"]:
+                        quan1 = handle_saturation(dic, val.lower(), nrst)
                     else:
                         print(f"Unknow -v variable ({val}).")
                         sys.exit()
@@ -376,6 +384,8 @@ def do_read_variables(dic, quans, n, ntot):
                 temp[i] = handle_mass(dic, quans[0].lower(), nrst)[ind]
             elif quans[0].lower() in dic["caprock"]:
                 temp[i], _ = handle_caprock(dic, quans[0].lower(), nrst)[ind]
+            elif quans[0].lower() in ["swat", "soil", "sgas"]:
+                temp[i] = handle_saturation(dic, quans[0].lower(), nrst)[ind]
             else:
                 print(f"Unknow -v variable ({quans[0]}).")
                 sys.exit()
@@ -397,6 +407,8 @@ def do_read_variables(dic, quans, n, ntot):
                         quan1 = handle_mass(dic, val.lower(), nrst)[ind]
                     elif val.lower() in dic["caprock"]:
                         quan1, _ = handle_caprock(dic, val.lower(), nrst)[ind]
+                    elif val.lower() in ["swat", "soil", "sgas"]:
+                        quan1 = handle_saturation(dic, val.lower(), nrst)[ind]
                     else:
                         print(f"Unknow -v variable ({val}).")
                         sys.exit()
@@ -1139,6 +1151,8 @@ def get_quantity(dic, name, n, nrst, m):
                 unit = initialize_mass(skl)
         elif names[0].lower() in dic["caprock"]:
             quan, unit = handle_caprock(dic, names[0].lower(), nrst)
+        elif names[0].lower() in ["swat", "soil", "sgas"]:
+            quan = handle_saturation(dic, names[0].lower(), nrst) * skl
         else:
             print(f"Unknow -v variable ({names[0]}).")
             sys.exit()
@@ -1164,6 +1178,35 @@ def get_quantity(dic, name, n, nrst, m):
         quan = np.array(quan)
         quan[float(dic["vmax"][n]) < quan] = np.nan
     return unit, quan
+
+
+def handle_saturation(dic, name, nrst):
+    """
+    Compute the oil saturation.
+
+    Args:
+        dic (dict): Global dictionary\n
+        name (str): Name of the variable for the saturation map\n
+        nrst (int): Number of restart step
+
+    Returns:
+        s (array): Floats with the saturation
+
+    """
+    soil = (
+        np.array(dic["unrst"]["SOIL", nrst]) if dic["unrst"].count("SOIL", nrst) else 0
+    )
+    sgas = (
+        np.array(dic["unrst"]["SGAS", nrst]) if dic["unrst"].count("SGAS", nrst) else 0
+    )
+    swat = (
+        np.array(dic["unrst"]["SWAT", nrst]) if dic["unrst"].count("SWAT", nrst) else 0
+    )
+    if name == "soil":
+        return 1 - sgas - swat
+    if name == "swat":
+        return 1 - sgas - soil
+    return 1 - soil - swat
 
 
 def handle_mass(dic, name, nrst):


### PR DESCRIPTION
## Description
Small fixes to find cases for diff in a folder, e.g., `-diff 'folder/.'`, and for slide in projections without specifying range for all cells in a direction, e.g., `-slide ,:,`
